### PR TITLE
Typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const pinoTransmitHttp = require('pino-transmit-http');
 
 const logger = pino({
   browser: {
-    trasmit: pinoTransmitHttp()
+    transmit: pinoTransmitHttp()
   }
 })
 


### PR DESCRIPTION
Was "trasmit" (missing "n"), changed to transmit