### PR TITLE
Add options for data formatting and error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function transmitHttp (inOpts) {
         : opts.headers
 
       // convert collected logs to string and clear the collector array
-      let data = (typeof opts.prepareBody === 'function')
+      const data = (typeof opts.prepareBody === 'function')
         ? await opts.prepareBody(collection)
         : JSON.stringify(collection)
       collection = []

--- a/index.js
+++ b/index.js
@@ -73,6 +73,12 @@ function transmitHttp (inOpts) {
       } catch (e) {
         console.error('pino-transmit-http: Failed to transmit logs')
       }
+    },
+    flush: async function () {
+      if (typeof send.flush === 'function') {
+        return send.flush()
+      }
+      return rawSend()
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-alpha.5",
   "description": "A pino browser transmit that send log statements over HTTP",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "tap --no-cov 'test/**/*.test.js'",
     "lint": "standard",
@@ -35,6 +36,7 @@
     "tap": "^10.2.2"
   },
   "dependencies": {
+    "@types/pino": "^4.16.1",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
   },
   "homepage": "https://github.com/sventschui/pino-transmit-http#readme",
   "devDependencies": {
-    "pino": "^4.17.3",
+    "pino": "^6.2.1",
     "pre-commit": "^1.2.2",
-    "snazzy": "^7.1.1",
-    "standard": "^9.0.0",
-    "tap": "^10.2.2"
+    "snazzy": "^8.0.0",
+    "standard": "^14.3.3",
+    "tap": "^14.10.7"
   },
   "dependencies": {
-    "@types/pino": "^4.16.1",
+    "@types/pino": "^6.0.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1"
   },
   "peerDependencies": {
-    "pino": "^4.17.3"
+    "pino": "^6.2.1"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,27 @@
+import { LogEvent } from 'pino';
+
+interface Headers {
+  [key: string]: string;
+}
+
+export interface TransmitHttpOptions {
+  throttle?: number;
+  debounce?: number;
+  url?: string;
+  useSendBeacon?: boolean;
+  method?: string;
+  fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  level?: string;
+  headers?: Headers | null;
+  onError?: (e: Error, data: string, headers: Headers) => any;
+  prepareBody?: (collection: LogEvent[]) => Promise<string>;
+  prepareHeaders?: (headers: Headers | null) => Promise<Headers | null>;
+}
+
+export interface BrowserTransmit {
+  level: string;
+  send: (level: string, logEvent: LogEvent) => Promise<void> | void;
+  flush: () => Promise<void> | void;
+}
+
+export default function transmitHttp(options?: TransmitHttpOptions): BrowserTransmit;


### PR DESCRIPTION
@sventschui are you interested in merging any of these commits into your repo? I needed the features for [ajwild/gcp-logger](https://github.com/ajwild/gcp-logger) - mostly so that I could add a JWT to the header and format the body for [Google Cloud Logging](https://cloud.google.com/logging/docs). I've also exposed the flush function so that I can use this with the `waitUntil` function in [Cloudflare Workers](https://developers.cloudflare.com/workers/reference/apis/fetch-event/).

I was also thinking of using a `preSend` function instead of `prepareHeaders` and `prepareBody` if you prefer the naming. If you feel it's all out-of-scope of this package then I'm happy enough to maintain a separate fork. If you want to merge then I'll add tests and documentation.